### PR TITLE
Relax Ruby version to at least 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
+  - 2.5.8
   - 2.6.5
   - 2.7.0
 env:

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ columns with the same name!
 `Xsv::Workbook.open` accepts a filename, or a IO or String containing a workbook.
 
 `Xsv::Sheet` implements `Enumerable` so you can call methods like `#first`,
-`#filter` and `#map` on it.
+`#filter`/`#select` and `#map` on it.
 
 ### Assumptions
 

--- a/test/sheet_test.rb
+++ b/test/sheet_test.rb
@@ -10,7 +10,7 @@ class SheetTest < Minitest::Test
     first_row = @workbook.sheets[0].first
     assert_equal @workbook.sheets[0][0], first_row
 
-    filtered_rows = @workbook.sheets[0].filter { |r| r[1].to_i > 2 }
+    filtered_rows = @workbook.sheets[0].select { |r| r[1].to_i > 2 }
     assert_equal 2, filtered_rows.length
   end
 end

--- a/xsv.gemspec
+++ b/xsv.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '~> 2.6'
+  spec.required_ruby_version = '~> 2.5'
 
   spec.add_dependency "rubyzip", ">= 1.3", "< 3"
   spec.add_dependency "ox", ">= 2.9"


### PR DESCRIPTION
Hello!

First of all, thanks for this well-timed gem! 

I was considering xlsx import gems, read a lot about the slow and memory hungry ones, found a suggestion to use Ox, started thinking about implementing a gem, and then stumbled upon yours :)

Now could you, please, accept this PR to relax Ruby version? (2.5 is still widely used (as well as 2.3 and 2.4 despite their EOL) and until fresh Ruby releases was more stable then 2.6.x and 2.7.x)