### PR TITLE
Sheet Names

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,22 @@ columns with the same name!
 `Xsv::Sheet` implements `Enumerable` so you can call methods like `#first`,
 `#filter`/`#select` and `#map` on it.
 
+The sheets could be accessed by index or by name:
+
+```ruby
+x = Xsv::Workbook.open("sheet.xlsx")
+
+sheet = x.sheets[0] # gets sheet by index
+
+sheet = x.sheets_by_name('Name').first # gets sheet by name
+```
+
+To get all the workbook's sheets names:
+
+```ruby
+sheet_names = x.sheets.map(&:name)
+```
+
 ### Assumptions
 
 Since Xsv treats worksheets like csv files it makes certain assumptions about your

--- a/lib/xsv.rb
+++ b/lib/xsv.rb
@@ -3,10 +3,12 @@ require "date"
 require "ox"
 
 require "xsv/helpers"
+require "xsv/relationships_handler"
 require "xsv/shared_strings_parser"
 require "xsv/sheet"
 require "xsv/sheet_bounds_handler"
 require "xsv/sheet_rows_handler"
+require 'xsv/sheets_ids_handler'
 require "xsv/styles_handler"
 require "xsv/version"
 require "xsv/workbook"

--- a/lib/xsv/relationships_handler.rb
+++ b/lib/xsv/relationships_handler.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+module Xsv
+  # RelationshipsHandler parses the "xl/_rels/workbook.xml.rels" file to get the existing relationships.
+  # This is used internally  when opening a workbook.
+  class RelationshipsHandler < Ox::Sax
+    def self.get_relations(io)
+      relations = []
+      handler = new do |relation|
+        relations << relation
+      end
+
+      Ox.sax_parse(handler, io.read)
+      return relations
+    end
+
+    # Ox::Sax implementation
+
+    def initialize(&block)
+      @block = block
+    end
+
+    def start_element(name)
+      @relationship = {} if name == :Relationship
+    end
+
+    def attr(name, value)
+      case name
+        when :Id, :Type, :Target
+          @relationship[name] = value
+      end
+    end
+
+    def end_element(name)
+      return unless name == :Relationship
+
+      @block.call(@relationship)
+    end
+  end
+end

--- a/lib/xsv/sheet.rb
+++ b/lib/xsv/sheet.rb
@@ -17,7 +17,7 @@ module Xsv
 
     # Returns the current mode. Call {#parse_headers!} to switch to `:hash` mode
     # @return [Symbol] `:hash` or `:array`
-    attr_reader :mode
+    attr_reader :id, :mode, :name
 
     # Set a number of rows to skip at the top of the sheet (header row offset).
     # For hash mode, do not skip the header row as this will be automatically
@@ -30,9 +30,11 @@ module Xsv
     # @param workbook [Workbook] The Workbook with shared data such as shared strings and styles
     # @param io [IO] A handle to an open worksheet XML file
     # @param size [Number] size of the XML file
-    def initialize(workbook, io, size)
+    def initialize(workbook, io, size, ids)
       @workbook = workbook
+      @id = ids[:sheetId].to_i
       @io = io
+      @name = ids[:name]
       @size = size
       @headers = []
       @mode = :array

--- a/lib/xsv/sheets_ids_handler.rb
+++ b/lib/xsv/sheets_ids_handler.rb
@@ -20,10 +20,16 @@ module Xsv
     end
 
     def start_element(name)
-      @sheet_ids = {} if name == :sheet
+      return @parsing = true if name == :sheets
+
+      return unless name == :sheet
+
+      @sheet_ids = {}
     end
 
     def attr(name, value)
+      return unless @parsing
+
       case name
         when :name, :sheetId
           @sheet_ids[name] = value
@@ -33,6 +39,8 @@ module Xsv
     end
 
     def end_element(name)
+      return @parsing = false if name == :sheets
+
       return unless name == :sheet
 
       @block.call(@sheet_ids)

--- a/lib/xsv/sheets_ids_handler.rb
+++ b/lib/xsv/sheets_ids_handler.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+module Xsv
+  # SheetsIdsHandler interprets the relevant parts of workbook.xml
+  # This is used internally to get the sheets ids, relationship_ids, and names when opening a workbook.
+  class SheetsIdsHandler < Ox::Sax
+    def self.get_sheets_ids(io)
+      sheets_ids = []
+      handler = new do |sheet_ids|
+        sheets_ids << sheet_ids
+      end
+
+      Ox.sax_parse(handler, io.read)
+      return sheets_ids
+    end
+
+    # Ox::Sax implementation
+
+    def initialize(&block)
+      @block = block
+    end
+
+    def start_element(name)
+      @sheet_ids = {} if name == :sheet
+    end
+
+    def attr(name, value)
+      case name
+        when :name, :sheetId
+          @sheet_ids[name] = value
+        when :'r:id'
+          @sheet_ids[:r_id] = value
+      end
+    end
+
+    def end_element(name)
+      return unless name == :sheet
+
+      @block.call(@sheet_ids)
+    end
+  end
+end

--- a/lib/xsv/workbook.rb
+++ b/lib/xsv/workbook.rb
@@ -65,6 +65,9 @@ module Xsv
       true
     end
 
+    # Returns an array of sheets for the case of same name sheets.
+    # @param [String] name
+    # @return [Array<Xsv::Sheet>]
     def sheets_by_name(name)
       @sheets.select { |s| s.name == name }
     end

--- a/lib/xsv/workbook.rb
+++ b/lib/xsv/workbook.rb
@@ -41,6 +41,8 @@ module Xsv
 
       fetch_shared_strings
       fetch_styles
+      fetch_sheets_ids
+      fetch_relationships
       fetch_sheets
     end
 
@@ -56,9 +58,15 @@ module Xsv
       @sheets = nil
       @xfs = nil
       @numFmts = nil
+      @relationships = nil
       @shared_strings = nil
+      @sheets_ids = nil
 
       true
+    end
+
+    def sheets_by_name(name)
+      @sheets.select { |s| s.name == name }
     end
 
     private
@@ -80,8 +88,24 @@ module Xsv
       @zip.glob("xl/worksheets/sheet*.xml").sort do |a, b|
         a.name[/\d+/].to_i <=> b.name[/\d+/].to_i
       end.each do |entry|
-        @sheets << Xsv::Sheet.new(self, entry.get_input_stream, entry.size)
+        rel = @relationships.select { |r| entry.name.end_with?(r[:Target]) && r[:Type].end_with?('worksheet') }[0]
+        sheet_ids = @sheets_ids.select { |i| i[:r_id] == rel[:Id] }[0]
+        @sheets << Xsv::Sheet.new(self, entry.get_input_stream, entry.size, sheet_ids)
       end
+    end
+
+    def fetch_sheets_ids
+      stream = @zip.glob("xl/workbook.xml").first.get_input_stream
+      @sheets_ids = SheetsIdsHandler.get_sheets_ids(stream)
+
+      stream.close
+    end
+
+    def fetch_relationships
+      stream = @zip.glob("xl/_rels/workbook.xml.rels").first.get_input_stream
+      @relationships = RelationshipsHandler.get_relations(stream)
+
+      stream.close
     end
   end
 end

--- a/lib/xsv/workbook.rb
+++ b/lib/xsv/workbook.rb
@@ -88,8 +88,8 @@ module Xsv
       @zip.glob("xl/worksheets/sheet*.xml").sort do |a, b|
         a.name[/\d+/].to_i <=> b.name[/\d+/].to_i
       end.each do |entry|
-        rel = @relationships.select { |r| entry.name.end_with?(r[:Target]) && r[:Type].end_with?('worksheet') }[0]
-        sheet_ids = @sheets_ids.select { |i| i[:r_id] == rel[:Id] }[0]
+        rel = @relationships.detect { |r| entry.name.end_with?(r[:Target]) && r[:Type].end_with?('worksheet') }
+        sheet_ids = @sheets_ids.detect { |i| i[:r_id] == rel[:Id] }
         @sheets << Xsv::Sheet.new(self, entry.get_input_stream, entry.size, sheet_ids)
       end
     end

--- a/test/excel_2016_test.rb
+++ b/test/excel_2016_test.rb
@@ -10,6 +10,22 @@ class Excel2016Test < Minitest::Test
     assert_nil @file.sheets[9]
   end
 
+  def test_return_sheets_name
+    assert_equal 'Basic types', @file.sheets[0].name
+    assert_equal 'Empty rows and columns', @file.sheets[1].name
+    assert_equal 'A graph', @file.sheets[2].name
+    assert_equal 'Merges and hides', @file.sheets[3].name
+    assert_equal 'Hidden sheet', @file.sheets[4].name
+  end
+
+  def test_access_sheets_by_name
+    assert_equal @file.sheets_by_name('Basic types').first.id, 1
+  end
+
+  def test_access_sheets_by_inexistent_name
+    assert_equal @file.sheets_by_name('Basic type').first, nil
+  end
+
   def test_access_row_by_index
     assert_kind_of Array, @file.sheets[0][0]
   end


### PR DESCRIPTION
Added `:id` and `:name` attribute to Sheet class (`:id` being unique, is useful for same name sheets).

Added `#sheets_by_name` method to Workbook class.