### PR TITLE
Implement a native Ruby XML parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: ruby
 cache: bundler
 rvm:
   - 2.5.8
-  - 2.7.1
+  - 3.0
   - truffleruby
   - jruby
 before_install: gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,4 @@ rvm:
   - 2.7.1
   - truffleruby
   - jruby
-env:
-  - "rubyzip=1.3.0"
-  - "rubyzip=2.2.0"
-  - "ox=2.9"
-  - "ox=2.13.2"
 before_install: gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ cache: bundler
 rvm:
   - 2.5.8
   - 2.7.1
+  - truffleruby
+  - jruby
 env:
   - "rubyzip=1.3.0"
   - "rubyzip=2.2.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Xsv Changelog
 
+## 1.0.0.pre 2021-01-18
+
+-  Switch to a minimalistic XML parser in native Ruby (#21)
+-  Ruby 3.0 compatibility
+-  Various internal cleanup and optimization
+-  API is backwards compatible with 0.3.x
+
 ## 0.3.18 2020-09-30
 
 -  Improve inline string support (#18)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Travis CI](https://img.shields.io/travis/martijn/xsv/master)](https://travis-ci.org/martijn/xsv)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://rubydoc.info/github/martijn/xsv)
 
+**This is an experimental branch with a pure-Ruby XML parser that perform well in any Ruby implementation. Use at your own risk.**
+
 Xsv is a fast, lightweight parser for Office Open XML spreadsheet files
 (commonly known as Excel or .xlsx files). It strives to be minimal in the
 sense that it provides nothing a CSV reader wouldn't, meaning it only
@@ -33,7 +35,7 @@ Or install it yourself as:
 
     $ gem install xsv
 
-Xsv targets ruby ~> 2.6 and depends on `rubyzip` and `ox`.
+Xsv targets ruby ~> 2.6 and depends on `rubyzip`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Travis CI](https://img.shields.io/travis/martijn/xsv/master)](https://travis-ci.org/martijn/xsv)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://rubydoc.info/github/martijn/xsv)
 
-**This is an experimental branch with a pure-Ruby XML parser that perform well in any Ruby implementation. Use at your own risk.**
+**This is an experimental branch with a pure-Ruby XML parser that should perform well in any Ruby implementation. Use at your own risk.**
 
 Xsv is a fast, lightweight parser for Office Open XML spreadsheet files
 (commonly known as Excel or .xlsx files). It strives to be minimal in the

--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 [![Travis CI](https://img.shields.io/travis/martijn/xsv/master)](https://travis-ci.org/martijn/xsv)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://rubydoc.info/github/martijn/xsv)
 
-**This is an experimental branch with a pure-Ruby XML parser that should perform well in any Ruby implementation. Use at your own risk.**
-
-Xsv is a fast, lightweight parser for Office Open XML spreadsheet files
+Xsv is a fast, lightweight, pure Ruby parser for Office Open XML spreadsheet files
 (commonly known as Excel or .xlsx files). It strives to be minimal in the
 sense that it provides nothing a CSV reader wouldn't, meaning it only
 deals with minimal formatting and cannot create or modify documents.
@@ -35,7 +33,10 @@ Or install it yourself as:
 
     $ gem install xsv
 
-Xsv targets ruby >= 2.6 and depends on `rubyzip`.
+Xsv targets ruby >= 2.5 and has a just single dependency, `rubyzip`. It has been
+tested successfully with MRI, JRuby, and TruffleRuby. Due to the lack of
+native extensions should work well in multi-threaded environments or in Ractor
+when that becomes stable.
 
 ## Usage
 
@@ -78,15 +79,15 @@ end
 sheet[1] # => {"header1" => "value1", "header2" => "value2"}
 ```
 
-Be aware that hash mode will lead to unpredictable results if you have multiple
-columns with the same name!
+Be aware that hash mode will lead to unpredictable results if the worksheet
+has multiple columns with the same header.
 
-`Xsv::Workbook.open` accepts a filename, or a IO or String containing a workbook.
+`Xsv::Workbook.open` accepts a filename, or an IO or String containing a workbook.
 
 `Xsv::Sheet` implements `Enumerable` so you can call methods like `#first`,
-`#filter`/`#select` and `#map` on it.
+`#filter`/`#select`, and `#map` on it.
 
-The sheets could be accessed by index or by name:
+The sheets can be accessed by index or by name:
 
 ```ruby
 x = Xsv::Workbook.open("sheet.xlsx")
@@ -96,7 +97,7 @@ sheet = x.sheets[0] # gets sheet by index
 sheet = x.sheets_by_name('Name').first # gets sheet by name
 ```
 
-To get all the workbook's sheets names:
+To get all the sheets names:
 
 ```ruby
 sheet_names = x.sheets.map(&:name)
@@ -131,8 +132,10 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 Xsv is faster and more memory efficient than other gems because of two things: it only _reads values_ from Excel files and it's based on a SAX-based parser instead of a DOM-based parser. If you want to read some background on this, check out my blog post on
 [Efficient XML parsing in Ruby](https://storck.io/posts/efficient-xml-parsing-in-ruby/).
 
-Jamie Schembri did a shootout of Xsv against various other Excel reading gems comparing parsing speed, memory usage and allocations.
+Jamie Schembri did a shootout of Xsv against various other Excel reading gems comparing parsing speed, memory usage, and allocations.
 Check our his blog post: [Faster Excel parsing in Ruby](https://blog.schembri.me/post/faster-excel-parsing-in-ruby/).
+
+Pre-1.0, Xsv used a native extension for XML parsing, which was faster than the native Ruby one (on MRI). But even with the native Ruby version generally Xsv still outperforms other Ruby parsing gems.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Or install it yourself as:
 
     $ gem install xsv
 
-Xsv targets ruby ~> 2.6 and depends on `rubyzip`.
+Xsv targets ruby >= 2.6 and depends on `rubyzip`.
 
 ## Usage
 

--- a/lib/xsv.rb
+++ b/lib/xsv.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 require "date"
-require "ox"
 
 require "xsv/helpers"
+require "xsv/sax_parser"
 require "xsv/relationships_handler"
 require "xsv/shared_strings_parser"
 require "xsv/sheet"

--- a/lib/xsv.rb
+++ b/lib/xsv.rb
@@ -1,17 +1,18 @@
 # frozen_string_literal: true
-require "date"
 
-require "xsv/helpers"
-require "xsv/sax_parser"
-require "xsv/relationships_handler"
-require "xsv/shared_strings_parser"
-require "xsv/sheet"
-require "xsv/sheet_bounds_handler"
-require "xsv/sheet_rows_handler"
-require "xsv/sheets_ids_handler"
-require "xsv/styles_handler"
-require "xsv/version"
-require "xsv/workbook"
+require 'date'
+
+require 'xsv/helpers'
+require 'xsv/sax_parser'
+require 'xsv/relationships_handler'
+require 'xsv/shared_strings_parser'
+require 'xsv/sheet'
+require 'xsv/sheet_bounds_handler'
+require 'xsv/sheet_rows_handler'
+require 'xsv/sheets_ids_handler'
+require 'xsv/styles_handler'
+require 'xsv/version'
+require 'xsv/workbook'
 
 # XSV is a fast, lightweight parser for Office Open XML spreadsheet files
 # (commonly known as Excel or .xlsx files). It strives to be minimal in the

--- a/lib/xsv/helpers.rb
+++ b/lib/xsv/helpers.rb
@@ -1,52 +1,54 @@
 # frozen_string_literal: true
+
 module Xsv
   module Helpers
     # The default OOXML Spreadheet number formats according to the ECMA standard
     # User formats are appended from index 174 onward
     BUILT_IN_NUMBER_FORMATS = {
-      1 => "0",
-      2 => "0.00",
-      3 => "#, ##0",
-      4 => "#, ##0.00",
-      5 => "$#, ##0_);($#, ##0)",
-      6 => "$#, ##0_);[Red]($#, ##0)",
-      7 => "$#, ##0.00_);($#, ##0.00)",
-      8 => "$#, ##0.00_);[Red]($#, ##0.00)",
-      9 => "0%",
-      10 => "0.00%",
-      11 => "0.00E+00",
-      12 => "# ?/?",
-      13 => "# ??/??",
-      14 => "m/d/yyyy",
-      15 => "d-mmm-yy",
-      16 => "d-mmm",
-      17 => "mmm-yy",
-      18 => "h:mm AM/PM",
-      19 => "h:mm:ss AM/PM",
-      20 => "h:mm",
-      21 => "h:mm:ss",
-      22 => "m/d/yyyy h:mm",
-      37 => "#, ##0_);(#, ##0)",
-      38 => "#, ##0_);[Red](#, ##0)",
-      39 => "#, ##0.00_);(#, ##0.00)",
-      40 => "#, ##0.00_);[Red](#, ##0.00)",
-      45 => "mm:ss",
-      46 => "[h]:mm:ss",
-      47 => "mm:ss.0",
-      48 => "##0.0E+0",
-      49 => "@",
+      1 => '0',
+      2 => '0.00',
+      3 => '#, ##0',
+      4 => '#, ##0.00',
+      5 => '$#, ##0_);($#, ##0)',
+      6 => '$#, ##0_);[Red]($#, ##0)',
+      7 => '$#, ##0.00_);($#, ##0.00)',
+      8 => '$#, ##0.00_);[Red]($#, ##0.00)',
+      9 => '0%',
+      10 => '0.00%',
+      11 => '0.00E+00',
+      12 => '# ?/?',
+      13 => '# ??/??',
+      14 => 'm/d/yyyy',
+      15 => 'd-mmm-yy',
+      16 => 'd-mmm',
+      17 => 'mmm-yy',
+      18 => 'h:mm AM/PM',
+      19 => 'h:mm:ss AM/PM',
+      20 => 'h:mm',
+      21 => 'h:mm:ss',
+      22 => 'm/d/yyyy h:mm',
+      37 => '#, ##0_);(#, ##0)',
+      38 => '#, ##0_);[Red](#, ##0)',
+      39 => '#, ##0.00_);(#, ##0.00)',
+      40 => '#, ##0.00_);[Red](#, ##0.00)',
+      45 => 'mm:ss',
+      46 => '[h]:mm:ss',
+      47 => 'mm:ss.0',
+      48 => '##0.0E+0',
+      49 => '@'
     }.freeze
 
-    MINUTE = 60.freeze
-    HOUR = 3600.freeze
-    A_CODEPOINT = "A".ord.freeze
+    MINUTE = 60
+    HOUR = 3600
+    A_CODEPOINT = 'A'.ord.freeze
     # The epoch for all dates in OOXML Spreadsheet documents
     EPOCH = Date.new(1899, 12, 30).freeze
 
     # Return the index number for the given Excel column name (i.e. "A1" => 0)
     def column_index(col)
       col.each_codepoint.reduce(0) do |sum, n|
-        break sum - 1 if n < A_CODEPOINT  # reached a number
+        break sum - 1 if n < A_CODEPOINT # reached a number
+
         sum * 26 + (n - A_CODEPOINT + 1)
       end
     end
@@ -59,9 +61,7 @@ module Xsv
     # Return a time as a string for the given Excel time value
     def parse_time(number)
       # Disregard date part
-      if number > 0
-        number = number - number.truncate
-      end
+      number -= number.truncate if number.positive?
 
       base = number * 24
 
@@ -70,11 +70,11 @@ module Xsv
 
       # Compensate for rounding errors
       if minutes >= 60
-        hours = hours + (minutes / 60)
+        hours += (minutes / 60)
         minutes = minutes % 60
       end
 
-      "%02d:%02d" % [hours, minutes]
+      format('%02d:%02d', hours, minutes)
     end
 
     # Returns a time including a date as a {Time} object
@@ -92,9 +92,9 @@ module Xsv
 
     # Returns a number as either Integer or Float
     def parse_number(string)
-      if string.include? "."
+      if string.include? '.'
         string.to_f
-      elsif string.include? "E"
+      elsif string.include? 'E'
         Complex(string).to_f
       else
         string.to_i
@@ -124,6 +124,7 @@ module Xsv
     # Tests if the given format string is a date
     def is_date_format?(format)
       return false if format.nil?
+
       # If it contains at least 2 sequences of d's, m's or y's it's a date!
       format.scan(/[dmy]+/).length > 1
     end
@@ -131,6 +132,7 @@ module Xsv
     # Tests if the given format string is a time
     def is_time_format?(format)
       return false if format.nil?
+
       # If it contains at least 2 sequences of h's, m's or s's it's a time!
       format.scan(/[hms]+/).length > 1
     end

--- a/lib/xsv/helpers.rb
+++ b/lib/xsv/helpers.rb
@@ -105,11 +105,11 @@ module Xsv
     def parse_number_format(number, format)
       number = parse_number(number) if number.is_a?(String)
 
-      if is_datetime_format?(format)
+      if datetime_format?(format)
         parse_datetime(number)
-      elsif is_date_format?(format)
+      elsif date_format?(format)
         parse_date(number)
-      elsif is_time_format?(format)
+      elsif time_format?(format)
         parse_time(number)
       else
         number
@@ -117,12 +117,12 @@ module Xsv
     end
 
     # Tests if the given format string includes both date and time
-    def is_datetime_format?(format)
-      is_date_format?(format) && is_time_format?(format)
+    def datetime_format?(format)
+      date_format?(format) && time_format?(format)
     end
 
     # Tests if the given format string is a date
-    def is_date_format?(format)
+    def date_format?(format)
       return false if format.nil?
 
       # If it contains at least 2 sequences of d's, m's or y's it's a date!
@@ -130,7 +130,7 @@ module Xsv
     end
 
     # Tests if the given format string is a time
-    def is_time_format?(format)
+    def time_format?(format)
       return false if format.nil?
 
       # If it contains at least 2 sequences of h's, m's or s's it's a time!

--- a/lib/xsv/relationships_handler.rb
+++ b/lib/xsv/relationships_handler.rb
@@ -2,39 +2,21 @@
 module Xsv
   # RelationshipsHandler parses the "xl/_rels/workbook.xml.rels" file to get the existing relationships.
   # This is used internally  when opening a workbook.
-  class RelationshipsHandler < Ox::Sax
+  class RelationshipsHandler < SaxParser
     def self.get_relations(io)
       relations = []
-      handler = new do |relation|
-        relations << relation
-      end
 
-      Ox.sax_parse(handler, io.read)
+      new { |relation| relations << relation }.parse(io)
+
       return relations
     end
 
-    # Ox::Sax implementation
-
     def initialize(&block)
       @block = block
-      @relationship = {}
     end
 
-    def start_element(name)
-      @relationship = {} if name == :Relationship
-    end
-
-    def attr(name, value)
-      case name
-      when :Id, :Type, :Target
-        @relationship[name] = value
-      end
-    end
-
-    def end_element(name)
-      return unless name == :Relationship
-
-      @block.call(@relationship)
+    def start_element(name, attrs)
+      @block.call(attrs.map { |k, v| [k.to_sym, v] }.to_h.slice(*%i{Id Type Target})) if name == "Relationship"
     end
   end
 end

--- a/lib/xsv/relationships_handler.rb
+++ b/lib/xsv/relationships_handler.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Xsv
   # RelationshipsHandler parses the "xl/_rels/workbook.xml.rels" file to get the existing relationships.
   # This is used internally  when opening a workbook.
@@ -8,7 +9,7 @@ module Xsv
 
       new { |relation| relations << relation }.parse(io)
 
-      return relations
+      relations
     end
 
     def initialize(&block)

--- a/lib/xsv/relationships_handler.rb
+++ b/lib/xsv/relationships_handler.rb
@@ -16,7 +16,7 @@ module Xsv
     end
 
     def start_element(name, attrs)
-      @block.call(attrs.slice(*%i{Id Type Target})) if name == "Relationship"
+      @block.call(attrs.slice(:Id, :Type, :Target)) if name == 'Relationship'
     end
   end
 end

--- a/lib/xsv/relationships_handler.rb
+++ b/lib/xsv/relationships_handler.rb
@@ -16,7 +16,7 @@ module Xsv
     end
 
     def start_element(name, attrs)
-      @block.call(attrs.map { |k, v| [k.to_sym, v] }.to_h.slice(*%i{Id Type Target})) if name == "Relationship"
+      @block.call(attrs.slice(*%i{Id Type Target})) if name == "Relationship"
     end
   end
 end

--- a/lib/xsv/sax_parser.rb
+++ b/lib/xsv/sax_parser.rb
@@ -45,11 +45,11 @@ module Xsv
         end
 
         if state == :look_end
-          if o = pbuf.index('>')
+          if (o = pbuf.index('>'))
             tag_name, args = pbuf.slice!(0, o + 1).chop!.split(' ', 2)
 
-            if tag_name.start_with?('/') && respond_to?(:end_element)
-              end_element(tag_name[1..-1])
+            if tag_name.start_with?('/')
+              end_element(tag_name[1..-1]) if respond_to?(:end_element)
             else
               if args.nil?
                 start_element(tag_name, nil)

--- a/lib/xsv/sax_parser.rb
+++ b/lib/xsv/sax_parser.rb
@@ -51,11 +51,11 @@ module Xsv
         end
 
         if state == :look_end
-          if o = pbuf.index(">")
+          if o = pbuf.index('>')
             tag_name, args = pbuf.slice!(0, o+1).chop.split(' ', 2)
 
             if tag_name.start_with?('/')
-              @callbacks[:end_element]&.call(tag_name[1..])
+              @callbacks[:end_element]&.call(tag_name[1..-1])
             else
               if args.nil?
                 @callbacks[:start_element]&.call(tag_name, nil)

--- a/lib/xsv/sax_parser.rb
+++ b/lib/xsv/sax_parser.rb
@@ -1,0 +1,76 @@
+module Xsv
+  class SaxParser
+    def emit(callback, *args)
+      @callbacks[callback]&.call(*args)
+    end
+
+    def parse_args(args)
+      return nil if args.nil?
+
+      args.scan(/((\S+)\=\"(.*?)\")/).map { |m| m[1..2] }.to_h
+    end
+
+    def parse(io)
+      @callbacks = {
+        start_element: respond_to?(:start_element) ? method(:start_element) : nil,
+        end_element: respond_to?(:end_element) ? method(:end_element) : nil,
+        characters: respond_to?(:characters) ? method(:characters) : nil
+      }
+
+      pbuf = String.new("", capacity: 768)
+      state = :look_start
+      is_close = false
+      is_selfclose = false
+      eof_reached = false
+      force_read = false
+
+      pbuf = io.dup if io.is_a?(String)
+
+      while !eof_reached || !pbuf.empty?
+        begin
+          # Keep buffer size below 768 bytes, unless we need more to progress to the next state
+          if force_read || pbuf.length < 128
+            pbuf << io.sysread(512)
+            force_read = false
+          end
+        rescue EOFError, TypeError, NoMethodError
+          # EOFError is thrown by IO
+          # When reading from zip no EOFError is thrown, instead systead returns nil
+          # When reading from a String there is no sysread method
+          eof_reached = true
+        end
+
+        case state
+        when :look_start
+          if o = pbuf.index("<")
+            chars = pbuf.slice!(0, o+1).chop
+            emit(:characters, chars) unless chars.empty?
+
+            is_close = pbuf[0] == "/"
+            state = :look_end
+          else
+            force_read = true
+          end
+        when :look_end
+          if o = pbuf.index(">")
+            tag_name, args = pbuf.slice!(0, o+1).chop.split(" ", 2)
+            is_selfclose = args ? args[-1] == "/" : nil
+
+            if is_close
+              emit(:end_element, tag_name[1..-1])
+            else
+              emit(:start_element, tag_name, parse_args(args))
+              emit(:end_element, tag_name) if is_selfclose
+            end
+            state = :look_start
+          else
+            force_read = true
+          end
+        end
+
+        # Don't hang on trailing newline
+        pbuf.clear if eof_reached && state == :look_start && pbuf.size < 3
+      end
+    end
+  end
+end

--- a/lib/xsv/shared_strings_parser.rb
+++ b/lib/xsv/shared_strings_parser.rb
@@ -2,11 +2,10 @@
 module Xsv
   # Interpret the sharedStrings.xml file from the workbook
   # This is used internally when opening a sheet.
-  class SharedStringsParser < Ox::Sax
+  class SharedStringsParser < SaxParser
     def self.parse(io)
       strings = []
-      handler = new { |s| strings << s }
-      Ox.sax_parse(handler, io.read, skip: :skip_none)
+      new { |s| strings << s }.parse(io)
       return strings
     end
 
@@ -15,24 +14,24 @@ module Xsv
       @state = nil
     end
 
-    def start_element(name)
+    def start_element(name, attrs)
       case name
-      when :si
+      when "si"
         @current_string = ""
-      when :t
+      when "t"
         @state = name
       end
     end
 
-    def text(value)
-      @current_string += value if @state == :t
+    def characters(value)
+      @current_string += value if @state == "t"
     end
 
     def end_element(name)
       case name
-      when :si
+      when "si"
         @block.call(@current_string)
-      when :t
+      when "t"
         @state = nil
       end
     end

--- a/lib/xsv/shared_strings_parser.rb
+++ b/lib/xsv/shared_strings_parser.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Xsv
   # Interpret the sharedStrings.xml file from the workbook
   # This is used internally when opening a sheet.
@@ -6,7 +7,7 @@ module Xsv
     def self.parse(io)
       strings = []
       new { |s| strings << s }.parse(io)
-      return strings
+      strings
     end
 
     def initialize(&block)
@@ -14,24 +15,24 @@ module Xsv
       @state = nil
     end
 
-    def start_element(name, attrs)
+    def start_element(name, _attrs)
       case name
-      when "si"
-        @current_string = ""
-      when "t"
+      when 'si'
+        @current_string = ''
+      when 't'
         @state = name
       end
     end
 
     def characters(value)
-      @current_string += value if @state == "t"
+      @current_string += value if @state == 't'
     end
 
     def end_element(name)
       case name
-      when "si"
+      when 'si'
         @block.call(@current_string)
-      when "t"
+      when 't'
         @state = nil
       end
     end

--- a/lib/xsv/sheet.rb
+++ b/lib/xsv/sheet.rb
@@ -60,15 +60,7 @@ module Xsv
 
       handler = SheetRowsHandler.new(@mode, empty_row, @workbook, @row_skip, @last_row, &block)
 
-      # For smaller sheets, memory performance is a lot better if Ox is
-      # handed a string. For larger sheets this leads to awful performance.
-      # This is probably caused by either something in SheetRowsHandler or
-      # the interaction between Zip::InputStream and Ox
-      if @size > 100_000_000
-        Ox.sax_parse(handler, @io)
-      else
-        Ox.sax_parse(handler, @io.read)
-      end
+      handler.parse(@io)
 
       true
     end

--- a/lib/xsv/sheet.rb
+++ b/lib/xsv/sheet.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Xsv
   # Sheet represents a single worksheet from a workbook and is normally accessed through {Workbook#sheets}
   #
@@ -39,14 +40,14 @@ module Xsv
       @headers = []
       @mode = :array
       @row_skip = 0
-      @hidden = ids[:state] == "hidden"
+      @hidden = ids[:state] == 'hidden'
 
       @last_row, @column_count = SheetBoundsHandler.get_bounds(@io, @workbook)
     end
 
     # @return [String]
     def inspect
-      "#<#{self.class.name}:#{self.object_id}>"
+      "#<#{self.class.name}:#{object_id}>"
     end
 
     # Returns true if the worksheet is hidden
@@ -74,7 +75,7 @@ module Xsv
         return row if i == number
       end
 
-      return empty_row
+      empty_row
     end
 
     # Load headers in the top row of the worksheet. After parsing of headers

--- a/lib/xsv/sheet_bounds_handler.rb
+++ b/lib/xsv/sheet_bounds_handler.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Xsv
   # SheetBoundsHandler scans a sheet looking for the outer bounds of the content within.
   # This is used internally when opening a sheet to deal with worksheets that do not
@@ -21,7 +22,7 @@ module Xsv
 
       handler.parse(sheet)
 
-      return rows, cols
+      [rows, cols]
     end
 
     def initialize(trim_empty_rows, &block)
@@ -36,20 +37,20 @@ module Xsv
 
     def start_element(name, attrs)
       case name
-      when "c"
+      when 'c'
         @state = name
         @cell = attrs[:r]
-      when "v"
+      when 'v'
         col = column_index(@cell)
         @maxColumn = col if col > @maxColumn
         @maxRow = @row if @row > @maxRow
-      when "row"
+      when 'row'
         @state = name
         @row = attrs[:r].to_i
-      when "dimension"
+      when 'dimension'
         @state = name
 
-        _firstCell, lastCell = attrs[:ref].split(":")
+        _firstCell, lastCell = attrs[:ref].split(':')
 
         if lastCell
           @maxColumn = column_index(lastCell)
@@ -62,9 +63,7 @@ module Xsv
     end
 
     def end_element(name)
-      if name == "sheetData"
-        @block.call(@maxRow, @maxColumn)
-      end
+      @block.call(@maxRow, @maxColumn) if name == 'sheetData'
     end
   end
 end

--- a/lib/xsv/sheet_bounds_handler.rb
+++ b/lib/xsv/sheet_bounds_handler.rb
@@ -38,18 +38,18 @@ module Xsv
       case name
       when "c"
         @state = name
-        @cell = attrs.to_h["r"]
+        @cell = attrs[:r]
       when "v"
         col = column_index(@cell)
         @maxColumn = col if col > @maxColumn
         @maxRow = @row if @row > @maxRow
       when "row"
         @state = name
-        @row = attrs.to_h["r"].to_i
+        @row = attrs[:r].to_i
       when "dimension"
         @state = name
 
-        _firstCell, lastCell = attrs.to_h["ref"].split(":")
+        _firstCell, lastCell = attrs[:ref].split(":")
 
         if lastCell
           @maxColumn = column_index(lastCell)

--- a/lib/xsv/sheet_rows_handler.rb
+++ b/lib/xsv/sheet_rows_handler.rb
@@ -12,7 +12,7 @@ module Xsv
       when "s"
         @workbook.shared_strings[@current_value.to_i]
       when "str", "inlineStr"
-        @current_value.dup
+        @current_value.strip
       when "e" # N/A
         nil
       when nil, "n"
@@ -67,10 +67,9 @@ module Xsv
       when "row"
         @state = name
         @current_row = @empty_row.dup
-        @current_row_attrs.clear
-      when "t"
-        @state = nil unless @state == :is
         @current_row_attrs = attrs
+      when "t"
+        @state = nil unless @state == "is"
       else
         @state = nil
       end

--- a/lib/xsv/sheet_rows_handler.rb
+++ b/lib/xsv/sheet_rows_handler.rb
@@ -60,7 +60,7 @@ module Xsv
       case name
       when "c"
         @state = name
-        @current_cell = attrs.map { |k, v| [k.to_sym, v] }.to_h
+        @current_cell = attrs
         @current_value.clear
       when "v", "is"
         @state = name
@@ -70,7 +70,7 @@ module Xsv
         @current_row_attrs.clear
       when "t"
         @state = nil unless @state == :is
-        @current_row_attrs = attrs.map { |k, v| [k.to_sym, v] }.to_h
+        @current_row_attrs = attrs
       else
         @state = nil
       end

--- a/lib/xsv/sheet_rows_handler.rb
+++ b/lib/xsv/sheet_rows_handler.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Xsv
   # This is the core worksheet parser, implemented as an Ox::Sax handler. This is
   # used internally to enumerate rows.
@@ -9,13 +10,13 @@ module Xsv
       return nil if @current_value.empty?
 
       case @current_cell[:t]
-      when "s"
+      when 's'
         @workbook.shared_strings[@current_value.to_i]
-      when "str", "inlineStr"
+      when 'str', 'inlineStr'
         @current_value.strip
-      when "e" # N/A
+      when 'e' # N/A
         nil
-      when nil, "n"
+      when nil, 'n'
         if @current_cell[:s]
           style = @workbook.xfs[@current_cell[:s].to_i]
           numFmt = @workbook.numFmts[style[:numFmtId].to_i]
@@ -24,8 +25,8 @@ module Xsv
         else
           parse_number(@current_value)
         end
-      when "b"
-        @current_value == "1"
+      when 'b'
+        @current_value == '1'
       else
         raise Xsv::Error, "Encountered unknown column type #{@current_cell[:t]}"
       end
@@ -51,41 +52,37 @@ module Xsv
       @current_value = String.new
       @last_row = last_row
 
-      if @mode == :hash
-        @headers = @empty_row.keys
-      end
+      @headers = @empty_row.keys if @mode == :hash
     end
 
     def start_element(name, attrs)
       case name
-      when "c"
+      when 'c'
         @state = name
         @current_cell = attrs
         @current_value.clear
-      when "v", "is"
+      when 'v', 'is'
         @state = name
-      when "row"
+      when 'row'
         @state = name
         @current_row = @empty_row.dup
         @current_row_attrs = attrs
-      when "t"
-        @state = nil unless @state == "is"
+      when 't'
+        @state = nil unless @state == 'is'
       else
         @state = nil
       end
     end
 
     def characters(value)
-      if @state == "v" || @state == "is"
-        @current_value << value
-      end
+      @current_value << value if @state == 'v' || @state == 'is'
     end
 
     def end_element(name)
       case name
-      when "v"
+      when 'v'
         @state = nil
-      when "c"
+      when 'c'
         col_index = column_index(@current_cell[:r])
 
         case @mode
@@ -94,13 +91,11 @@ module Xsv
         when :hash
           @current_row[@headers[col_index]] = format_cell
         end
-      when "row"
+      when 'row'
         @real_row_number = @current_row_attrs[:r].to_i
         @adjusted_row_number = @real_row_number - @row_skip
 
-        if @real_row_number <= @row_skip
-          return
-        end
+        return if @real_row_number <= @row_skip
 
         @row_index += 1
 

--- a/lib/xsv/sheets_ids_handler.rb
+++ b/lib/xsv/sheets_ids_handler.rb
@@ -16,7 +16,7 @@ module Xsv
     end
 
     def start_element(name, attrs)
-      @block.call(attrs.map { |k, v| [k.to_sym, v] }.to_h.slice(*%i{name sheetId state r:id})) if name == "sheet"
+      @block.call(attrs.slice(*%i{name sheetId state r:id})) if name == "sheet"
     end
   end
 end

--- a/lib/xsv/sheets_ids_handler.rb
+++ b/lib/xsv/sheets_ids_handler.rb
@@ -2,55 +2,21 @@
 module Xsv
   # SheetsIdsHandler interprets the relevant parts of workbook.xml
   # This is used internally to get the sheets ids, relationship_ids, and names when opening a workbook.
-  class SheetsIdsHandler < Ox::Sax
+  class SheetsIdsHandler < SaxParser
     def self.get_sheets_ids(io)
       sheets_ids = []
-      handler = new do |sheet_ids|
-        sheets_ids << sheet_ids
-      end
 
-      Ox.sax_parse(handler, io.read)
+      new { |sheet_ids| sheets_ids << sheet_ids }.parse(io)
+
       return sheets_ids
     end
 
-    # Ox::Sax implementation
-
     def initialize(&block)
       @block = block
-      @parsing = false
     end
 
-    def start_element(name)
-      if name == :sheets
-        @parsing = true
-        return
-      end
-
-      return unless name == :sheet
-
-      @sheet_ids = {}
-    end
-
-    def attr(name, value)
-      return unless @parsing
-
-      case name
-      when :name, :sheetId, :state
-        @sheet_ids[name] = value
-      when :'r:id'
-        @sheet_ids[:r_id] = value
-      end
-    end
-
-    def end_element(name)
-      if name == :sheets
-        @parsing = false
-        return
-      end
-
-      return unless name == :sheet
-
-      @block.call(@sheet_ids)
+    def start_element(name, attrs)
+      @block.call(attrs.map { |k, v| [k.to_sym, v] }.to_h.slice(*%i{name sheetId state r:id})) if name == "sheet"
     end
   end
 end

--- a/lib/xsv/sheets_ids_handler.rb
+++ b/lib/xsv/sheets_ids_handler.rb
@@ -16,7 +16,7 @@ module Xsv
     end
 
     def start_element(name, attrs)
-      @block.call(attrs.slice(*%i{name sheetId state r:id})) if name == "sheet"
+      @block.call(attrs.slice(:name, :sheetId, :state, :'r:id')) if name == 'sheet'
     end
   end
 end

--- a/lib/xsv/sheets_ids_handler.rb
+++ b/lib/xsv/sheets_ids_handler.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Xsv
   # SheetsIdsHandler interprets the relevant parts of workbook.xml
   # This is used internally to get the sheets ids, relationship_ids, and names when opening a workbook.
@@ -8,7 +9,7 @@ module Xsv
 
       new { |sheet_ids| sheets_ids << sheet_ids }.parse(io)
 
-      return sheets_ids
+      sheets_ids
     end
 
     def initialize(&block)

--- a/lib/xsv/styles_handler.rb
+++ b/lib/xsv/styles_handler.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Xsv
   # StylesHandler interprets the relevant parts of styles.xml
   # This is used internally when opening a sheet.
@@ -13,7 +14,7 @@ module Xsv
 
       handler.parse(io)
 
-      return @xfs, @numFmts
+      [@xfs, @numFmts]
     end
 
     def initialize(numFmts, &block)
@@ -25,19 +26,19 @@ module Xsv
 
     def start_element(name, attrs)
       case name
-      when "cellXfs"
-        @state = "cellXfs"
-      when "xf"
-        @xfs << attrs if @state == "cellXfs"
-      when "numFmt"
+      when 'cellXfs'
+        @state = 'cellXfs'
+      when 'xf'
+        @xfs << attrs if @state == 'cellXfs'
+      when 'numFmt'
         @numFmts[attrs[:numFmtId].to_i] = attrs[:formatCode]
       end
     end
 
     def end_element(name)
-      if name == "styleSheet"
+      if name == 'styleSheet'
         @block.call(@xfs, @numFmts)
-      elsif name == "cellXfs"
+      elsif name == 'cellXfs'
         @state = nil
       end
     end

--- a/lib/xsv/styles_handler.rb
+++ b/lib/xsv/styles_handler.rb
@@ -28,10 +28,9 @@ module Xsv
       when "cellXfs"
         @state = "cellXfs"
       when "xf"
-        @xfs << attrs.map { |k, v| [k.to_sym, v] }.to_h if @state == "cellXfs"
+        @xfs << attrs if @state == "cellXfs"
       when "numFmt"
-        attr_h = attrs.map { |k, v| [k.to_sym, v] }.to_h
-        @numFmts[attr_h[:numFmtId].to_i] = attr_h[:formatCode]
+        @numFmts[attrs[:numFmtId].to_i] = attrs[:formatCode]
       end
     end
 

--- a/lib/xsv/styles_handler.rb
+++ b/lib/xsv/styles_handler.rb
@@ -4,10 +4,8 @@ module Xsv
   # StylesHandler interprets the relevant parts of styles.xml
   # This is used internally when opening a sheet.
   class StylesHandler < SaxParser
-    def self.get_styles(io, numFmts)
-      @xfs = nil
-      @numFmts = nil
-      handler = new(numFmts) do |xfs, numFmts|
+    def self.get_styles(io)
+      handler = new(Xsv::Helpers::BUILT_IN_NUMBER_FORMATS.dup) do |xfs, numFmts|
         @xfs = xfs
         @numFmts = numFmts
       end

--- a/lib/xsv/version.rb
+++ b/lib/xsv/version.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Xsv
-  VERSION = "0.3.18"
+  VERSION = '0.3.18'
 end

--- a/lib/xsv/version.rb
+++ b/lib/xsv/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Xsv
-  VERSION = '0.3.18'
+  VERSION = '1.0.0.pre'
 end

--- a/lib/xsv/workbook.rb
+++ b/lib/xsv/workbook.rb
@@ -95,7 +95,7 @@ module Xsv
         a.name[/\d+/].to_i <=> b.name[/\d+/].to_i
       end.each do |entry|
         rel = @relationships.detect { |r| entry.name.end_with?(r[:Target]) && r[:Type].end_with?("worksheet") }
-        sheet_ids = @sheets_ids.detect { |i| i[:r_id] == rel[:Id] }
+        sheet_ids = @sheets_ids.detect { |i| i[:"r:id"] == rel[:Id] }
         @sheets << Xsv::Sheet.new(self, entry.get_input_stream, entry.size, sheet_ids)
       end
     end

--- a/lib/xsv/workbook.rb
+++ b/lib/xsv/workbook.rb
@@ -17,7 +17,7 @@ module Xsv
     def self.open(data, **kws)
       @workbook = if data.is_a?(IO) || data.respond_to?(:read) # is it a buffer?
                     new(Zip::File.open_buffer(data), **kws)
-                  elsif data.start_with?("PK\x03\x04") # is it a string containing a filename?
+                  elsif data.start_with?("PK\x03\x04") # is it a string containing a file?
                     new(Zip::File.open_buffer(data), **kws)
                   else # must be a filename
                     new(Zip::File.open(data), **kws)
@@ -36,14 +36,11 @@ module Xsv
       @trim_empty_rows = trim_empty_rows
 
       @sheets = []
-      @xfs = []
-      @numFmts = Xsv::Helpers::BUILT_IN_NUMBER_FORMATS.dup
-
-      fetch_shared_strings
-      fetch_styles
-      fetch_sheets_ids
-      fetch_relationships
-      fetch_sheets
+      @xfs, @numFmts = fetch_styles
+      @sheet_ids = fetch_sheet_ids
+      @relationships = fetch_relationships
+      @shared_strings = fetch_shared_strings
+      @sheets = fetch_sheets
     end
 
     # @return [String]
@@ -60,7 +57,7 @@ module Xsv
       @numFmts = nil
       @relationships = nil
       @shared_strings = nil
-      @sheets_ids = nil
+      @sheet_ids = nil
 
       true
     end
@@ -79,38 +76,40 @@ module Xsv
       return if handle.nil?
 
       stream = handle.get_input_stream
-      @shared_strings = SharedStringsParser.parse(stream)
-
-      stream.close
+      SharedStringsParser.parse(stream)
+    ensure
+      stream.close if stream
     end
 
     def fetch_styles
       stream = @zip.glob('xl/styles.xml').first.get_input_stream
 
-      @xfs, @numFmts = StylesHandler.get_styles(stream, @numFmts)
+      StylesHandler.get_styles(stream)
+    ensure
+      stream.close
     end
 
     def fetch_sheets
       @zip.glob('xl/worksheets/sheet*.xml').sort do |a, b|
         a.name[/\d+/].to_i <=> b.name[/\d+/].to_i
-      end.each do |entry|
+      end.map do |entry|
         rel = @relationships.detect { |r| entry.name.end_with?(r[:Target]) && r[:Type].end_with?('worksheet') }
-        sheet_ids = @sheets_ids.detect { |i| i[:"r:id"] == rel[:Id] }
-        @sheets << Xsv::Sheet.new(self, entry.get_input_stream, entry.size, sheet_ids)
+        sheet_ids = @sheet_ids.detect { |i| i[:"r:id"] == rel[:Id] }
+        Xsv::Sheet.new(self, entry.get_input_stream, entry.size, sheet_ids)
       end
     end
 
-    def fetch_sheets_ids
+    def fetch_sheet_ids
       stream = @zip.glob('xl/workbook.xml').first.get_input_stream
-      @sheets_ids = SheetsIdsHandler.get_sheets_ids(stream)
-
+      SheetsIdsHandler.get_sheets_ids(stream)
+    ensure
       stream.close
     end
 
     def fetch_relationships
       stream = @zip.glob('xl/_rels/workbook.xml.rels').first.get_input_stream
-      @relationships = RelationshipsHandler.get_relations(stream)
-
+      RelationshipsHandler.get_relations(stream)
+    ensure
       stream.close
     end
   end

--- a/lib/xsv/workbook.rb
+++ b/lib/xsv/workbook.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
-require "zip"
+
+require 'zip'
 
 module Xsv
   # An OOXML Spreadsheet document is called a Workbook. A Workbook consists of
   # multiple Sheets that are available in the array that's accessible through {#sheets}
   class Workbook
-
     # Access the Sheet objects contained in the workbook
     # @return [Array<Sheet>]
     attr_reader :sheets
@@ -15,13 +15,13 @@ module Xsv
     # Open the workbook of the given filename, string or buffer. For additional
     # options see {.initialize}
     def self.open(data, **kws)
-      if data.is_a?(IO) || data.respond_to?(:read) # is it a buffer?
-        @workbook = self.new(Zip::File.open_buffer(data), **kws)
-      elsif data.start_with?("PK\x03\x04") # is it a string containing a filename?
-        @workbook = self.new(Zip::File.open_buffer(data), **kws)
-      else # must be a filename
-        @workbook = self.new(Zip::File.open(data), **kws)
-      end
+      @workbook = if data.is_a?(IO) || data.respond_to?(:read) # is it a buffer?
+                    new(Zip::File.open_buffer(data), **kws)
+                  elsif data.start_with?("PK\x03\x04") # is it a string containing a filename?
+                    new(Zip::File.open_buffer(data), **kws)
+                  else # must be a filename
+                    new(Zip::File.open(data), **kws)
+                  end
     end
 
     # Open a workbook from an instance of {Zip::File}. Generally it's recommended
@@ -48,7 +48,7 @@ module Xsv
 
     # @return [String]
     def inspect
-      "#<#{self.class.name}:#{self.object_id}>"
+      "#<#{self.class.name}:#{object_id}>"
     end
 
     # Close the handle to the workbook file and leave all resources for the GC to collect
@@ -75,7 +75,7 @@ module Xsv
     private
 
     def fetch_shared_strings
-      handle = @zip.glob("xl/sharedStrings.xml").first
+      handle = @zip.glob('xl/sharedStrings.xml').first
       return if handle.nil?
 
       stream = handle.get_input_stream
@@ -85,30 +85,30 @@ module Xsv
     end
 
     def fetch_styles
-      stream = @zip.glob("xl/styles.xml").first.get_input_stream
+      stream = @zip.glob('xl/styles.xml').first.get_input_stream
 
       @xfs, @numFmts = StylesHandler.get_styles(stream, @numFmts)
     end
 
     def fetch_sheets
-      @zip.glob("xl/worksheets/sheet*.xml").sort do |a, b|
+      @zip.glob('xl/worksheets/sheet*.xml').sort do |a, b|
         a.name[/\d+/].to_i <=> b.name[/\d+/].to_i
       end.each do |entry|
-        rel = @relationships.detect { |r| entry.name.end_with?(r[:Target]) && r[:Type].end_with?("worksheet") }
+        rel = @relationships.detect { |r| entry.name.end_with?(r[:Target]) && r[:Type].end_with?('worksheet') }
         sheet_ids = @sheets_ids.detect { |i| i[:"r:id"] == rel[:Id] }
         @sheets << Xsv::Sheet.new(self, entry.get_input_stream, entry.size, sheet_ids)
       end
     end
 
     def fetch_sheets_ids
-      stream = @zip.glob("xl/workbook.xml").first.get_input_stream
+      stream = @zip.glob('xl/workbook.xml').first.get_input_stream
       @sheets_ids = SheetsIdsHandler.get_sheets_ids(stream)
 
       stream.close
     end
 
     def fetch_relationships
-      stream = @zip.glob("xl/_rels/workbook.xml.rels").first.get_input_stream
+      stream = @zip.glob('xl/_rels/workbook.xml.rels').first.get_input_stream
       @relationships = RelationshipsHandler.get_relations(stream)
 
       stream.close

--- a/test/files/inlineStr.xml
+++ b/test/files/inlineStr.xml
@@ -13,6 +13,7 @@
           <t>This is Text</t>
         </is>
       </c>
+    </row>
   </sheetData>
   <pageMargins left="0.7" right="0.7" top="0.75" bottom="0.75" header="0.3" footer="0.3"/>
 </worksheet>

--- a/test/sheet_rows_handler_test.rb
+++ b/test/sheet_rows_handler_test.rb
@@ -69,7 +69,7 @@ class SheetRowsHandlerTest < Minitest::Test
     end
 
     handler = Xsv::SheetRowsHandler.new(:array, ([nil] * 10), @workbook, 0, 6, &collector)
-    Ox.sax_parse(handler, @sheet)
+    handler.parse(@sheet)
 
     assert_equal "This is Text", rows[0][0]
   end

--- a/test/sheet_rows_handler_test.rb
+++ b/test/sheet_rows_handler_test.rb
@@ -15,7 +15,7 @@ class SheetRowsHandlerTest < Minitest::Test
       rows << row
     end
 
-    Ox.sax_parse(handler, @sheet)
+    handler.parse(@sheet)
 
     assert_equal 4, rows.length
     assert_equal "Some strings", rows[0][0]
@@ -31,7 +31,7 @@ class SheetRowsHandlerTest < Minitest::Test
       rows << row
     end
 
-    Ox.sax_parse(handler, @sheet)
+    handler.parse(@sheet)
 
     assert_equal 3, rows.length
     assert_equal "Foo", rows[0]["Some strings"]
@@ -54,7 +54,7 @@ class SheetRowsHandlerTest < Minitest::Test
     (0..5).each do |row_skip|
       rows = []
       handler = Xsv::SheetRowsHandler.new(:array, ([nil] * 10), @workbook, row_skip, 6, &collector)
-      Ox.sax_parse(handler, @sheet)
+      handler.parse(@sheet)
       assert_equal first_columns[row_skip..-1], rows.map(&:first)
     end
   end

--- a/test/xsv_benchmark.rb
+++ b/test/xsv_benchmark.rb
@@ -5,7 +5,7 @@ class XsvBenchmark < Minitest::Benchmark
   def bench_row_access
     zip = File.read("test/files/10k-sheet.xlsx")
     x = Xsv::Workbook.open(zip)
-    assert_performance_linear do |n|
+    assert_performance_linear 0.001 do |n|
       x.sheets[0][n]
     end
   end
@@ -15,7 +15,7 @@ class XsvBenchmark < Minitest::Benchmark
     x = Xsv::Workbook.open(zip)
     x.sheets[0].parse_headers!
 
-    assert_performance_linear do |n|
+    assert_performance_linear 0.001 do |n|
       x.sheets[0].each_with_index do |row, i|
         row["A1"]
         break if i == n

--- a/test/xsv_benchmark.rb
+++ b/test/xsv_benchmark.rb
@@ -2,6 +2,13 @@ require "test_helper"
 require "minitest/benchmark"
 
 class XsvBenchmark < Minitest::Benchmark
+  def setup
+    return true if defined? $warmed_up
+    zip = File.read("test/files/10k-sheet.xlsx")
+    5.times { Xsv::Workbook.open(zip).sheets[0].each { nil } }
+    $warmed_up = true
+  end
+
   def bench_row_access
     zip = File.read("test/files/10k-sheet.xlsx")
     x = Xsv::Workbook.open(zip)

--- a/xsv.gemspec
+++ b/xsv.gemspec
@@ -39,7 +39,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = "~> 2.5"
 
   spec.add_dependency "rubyzip", ">= 1.3", "< 3"
-  spec.add_dependency "ox", ">= 2.9"
 
   spec.add_development_dependency "bundler", "< 3"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/xsv.gemspec
+++ b/xsv.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = "~> 2.5"
+  spec.required_ruby_version = ">= 2.5"
 
   spec.add_dependency "rubyzip", ">= 1.3", "< 3"
 

--- a/xsv.gemspec
+++ b/xsv.gemspec
@@ -42,5 +42,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "< 3"
   spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "minitest", "~> 5.14.2"
 end


### PR DESCRIPTION
This branch contains a naive pure-Ruby XML parser that could replace Ox, dropping this native extension dependency from Xsv. The benefit of this it can run in any Ruby and allows for parallelism in Ruby runtimes that support it. It should also be fully Ractor compatible.

Performance on MRI is slightly lower than with the old Ox-based parser, but still ahead of the competition. On TruffleRuby this native implementation is faster than the Ox-based one.

The parser will behave in unexpected ways with XML files that are not well-formed, but so far I haven't run into any of those in the wild.

I'd love for people to test this `native` branch in their application and report their findings in this issue.