### PR TITLE
Raise exception if given an empty buffer when opening workbook

### DIFF
--- a/lib/xsv/workbook.rb
+++ b/lib/xsv/workbook.rb
@@ -43,6 +43,7 @@ module Xsv
     #
     def initialize(zip, trim_empty_rows: false)
       raise ArgumentError, "Passed argument is not an instance of Zip::File. Did you mean to use Workbook.open?" unless zip.is_a?(Zip::File)
+      raise Xsv::Error, "Zip::File is empty" if zip.size.zero?
 
       @zip = zip
       @trim_empty_rows = trim_empty_rows

--- a/test/workbook_test.rb
+++ b/test/workbook_test.rb
@@ -64,4 +64,20 @@ class WorkbookTest < Minitest::Test
       Xsv::Workbook.new "not a Zip::File instance"
     end
   end
+
+  def test_open_empty_file_from_buffer
+    tempfile = Tempfile.new
+
+    assert_raises Xsv::Error do
+      @workbook = Xsv::Workbook.open(tempfile)
+    end
+  end
+
+  def test_open_empty_file_by_filename
+    tempfile = Tempfile.new
+
+    assert_raises Zip::Error do
+      Xsv::Workbook.open(tempfile.path)
+    end
+  end
 end


### PR DESCRIPTION
Prior to this change, when passing the name of an empty file to
Workbook.open, an exception would be raised because the underlying zip
library [does so](https://github.com/rubyzip/rubyzip/blob/e04c9cdbd8ddcca239c4628380dee7dd36de873b/lib/zip/file.rb#L100).

However, if you pass an empty buffer that can be read, prior to this
change, the workbook will attempt to read it and fail. It will fail
because when the initializer is attempting to set the styles, sheet IDs,
and relationships, it will not find the expected .xml file in the zip,
and therefore attempt to call `#get_input_stream` on `nil`, which will
fail.

Before determining those values, this modifies the initializer to check
to see when we get a buffer, which will pass the zip library's
checking of it being empty, if the `Zip::File` we receive has any size.

This makes the behavior consistent across different scenarios, where an
exception is raised. However, the *type* of exception differs. In the
buffer case, this will raise an exception from this library, as opposed
to the `Zip::Error` exception raised by that library itself.

## Alternative

I started down the path of instead modifying `Workbook#fetch_styles`,
`Workbook#fetch_sheet_ids`, and `Workbook#fetch_relationships` to behave
similarly to `Workbook#fetch_shared_strings`, so it only attempts to do
what it needs to do if it does find a corresponding file - and conditionally
closes the stream in the `ensure` block.

That would also get rid of the library raising an exception for trying to call 
`#get_input_stream` on `nil`. However, given the discrepancy in behavior for
how passing a file name vs. the file contents would react in that scenario, I opted
instead to raise an exception so it's consistent - an exception is raised in each case,
though the type of exception is different.