### PR TITLE
Optimize for YJIT by using while loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Xsv .xlsx reader for Ruby
 
 [![Test badge](https://img.shields.io/github/actions/workflow/status/martijn/xsv/ruby.yml?branch=main)](https://github.com/martijn/xsv/actions/workflows/ruby.yml)
-[![Codecov badge](https://img.shields.io/codecov/c/github/martijn/xsv/main)](https://app.codecov.io/gh/martijn/xsv)
 [![Yard Docs badge](http://img.shields.io/badge/yard-docs-blue.svg)](https://rubydoc.info/github/martijn/xsv)
 [![Gem Version badge](https://badge.fury.io/rb/xsv.svg)](https://badge.fury.io/rb/xsv)
 
@@ -176,6 +175,3 @@ for inclusion in the source code repository.
 Copyright © Martijn Storck and Xsv contributors
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
-
-
-

--- a/lib/xsv/helpers.rb
+++ b/lib/xsv/helpers.rb
@@ -35,7 +35,7 @@ module Xsv
       46 => "[h]:mm:ss",
       47 => "mm:ss.0",
       48 => "##0.0E+0",
-      49 => "@",
+      49 => "@"
     }.freeze
 
     MINUTE = 60
@@ -45,11 +45,14 @@ module Xsv
     EPOCH = Date.new(1899, 12, 30).freeze
 
     # Return the index number for the given Excel column name (i.e. "A1" => 0)
+    # @param col [String] Column name in A1 notation
     def column_index(col)
-      col.each_codepoint.reduce(0) do |sum, n|
-        break sum - 1 if n < A_CODEPOINT # reached a number
+      chars = col.bytes
+      sum = 0
+      while (char = chars.delete_at(0))
+        break sum - 1 if char < A_CODEPOINT # reached the number
 
-        sum * 26 + (n - A_CODEPOINT + 1)
+        sum = sum * 26 + (char - A_CODEPOINT + 1)
       end
     end
 

--- a/lib/xsv/sax_parser.rb
+++ b/lib/xsv/sax_parser.rb
@@ -74,7 +74,14 @@ module Xsv
             elsif args.nil?
               start_element(tag_name, nil)
             else
-              start_element(tag_name, args.scan(ATTR_REGEX).each_with_object({}) { |(_, k, v), h| h[k.to_sym] = v })
+              attribute_buffer = {}
+              attributes = args.scan(ATTR_REGEX)
+              while (attr = attributes.delete_at(0))
+                attribute_buffer[attr[1].to_sym] = attr[2]
+              end
+
+              start_element(tag_name, attribute_buffer)
+
               end_element(tag_name) if responds_to_end_element && args.end_with?("/")
             end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,3 @@
-require "simplecov"
-SimpleCov.start
-
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "xsv"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,11 +1,6 @@
 require "simplecov"
 SimpleCov.start
 
-if ENV["CI"]
-  require "codecov"
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
-end
-
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "xsv"
 

--- a/xsv.gemspec
+++ b/xsv.gemspec
@@ -44,5 +44,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.14.2"
   spec.add_development_dependency "standard", "~> 1.6.0"
-  spec.add_development_dependency "codecov", ">= 0.6.0"
 end


### PR DESCRIPTION
The code introduced in this change is not idiomatic ruby but improves performance in Ruby 3.3-rc1 and without YJIT enabled.

With YJIT the performance gain is about 5%, without YJIT it's 2%. YJIT is generally 15% faster in the basic Xsv benchmark.

For more information, see the code optimization tips in the [YJIT docs](https://github.com/ruby/ruby/blob/master/doc/yjit/yjit.md#code-optimization-tips)