### PR TITLE
Implement Enumerable in Workbook

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2', 'jruby', 'truffleruby']
+        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3', 'jruby', 'truffleruby']
 
     steps:
     - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## HEAD
 
-- Minor performance improvements in the XML parser
+- Ruby 2.6 is no longer supported. Xsv is compatible with Ruby 2.7 through 3.3, latest JRuby, and latest TruffleRuby
+- Easier access worksheets using `Xsv::Workbook#[]` and `Enumerable` methods on `Xsv::Workbook`. The old `sheets` and `sheet_by_name` method have been retained for backward compatibility.
 - Update of development dependencies including minitest and standardrb
+- Various performance improvements, especially with YJIT on Ruby 3.3
 
 ## 1.2.1 2023-05-09
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 Xsv is a high performance, lightweight, pure Ruby parser for ISO/IEC 29500 Office Open XML spreadsheets
 (commonly known as Excel or .xlsx files). It strives to be minimal in the sense that it provides nothing a
-CSV reader wouldn't. This means it only deals with the minimal required formatting and cannot create or modify documents.
+CSV reader wouldn't. This means it only deals with the minimal required formatting and cannot create or modify
+documents.
 Xsv can handle very large Excel files with minimal resources thanks to a custom streaming XML parser that
 is optimized for the Excel file format.
 
@@ -71,19 +72,19 @@ option on open:
 workbook = Xsv.open("sheet.xlsx", parse_headers: true)
 
 # Get the first row from the first sheet
-workbook.first.first   # => {"header1" => "value1", "header2" => "value2"}
+workbook.first.first # => {"header1" => "value1", "header2" => "value2"}
 
 # Manually parse headers for a single sheet
 
 workbook = Xsv.open("sheet.xlsx")
 
-sheet = workbook[0]
+sheet = workbook.first
 
-sheet[0]  # => ["header1", "header2"]
+sheet.first # => ["header1", "header2"]
 
 sheet.parse_headers!
 
-sheet[0] # => {"header1" => "value1", "header2" => "value2"}
+sheet.first # => {"header1" => "value1", "header2" => "value2"}
 ```
 
 Xsv will raise `Xsv::DuplicateHeaders` if it detects duplicate values in the header row when calling
@@ -135,26 +136,35 @@ If your data or headers do not start on the first row of the sheet you can
 tell Xsv to skip a number of rows:
 
 ```ruby
-workbook.sheets[0].row_skip = 1
+sheet = workbook[0]
+sheet.row_skip = 1
 ```
 
 All operations will honour this offset, making the skipped rows unreachable.
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can
+also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the
+version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version,
+push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Performance and Benchmarks
 
-Xsv is faster and more memory efficient than other gems because of two things: it only _reads values_ from Excel files and it's based on a SAX-based parser instead of a DOM-based parser. If you want to read some background on this, check out my blog post on
+Xsv is faster and more memory efficient than other gems because of two things: it only _reads values_ from Excel files
+and it's based on a SAX-based parser instead of a DOM-based parser. If you want to read some background on this, check
+out my blog post on
 [Efficient XML parsing in Ruby](https://storck.io/posts/efficient-xml-parsing-in-ruby/).
 
-Jamie Schembri did a shootout of Xsv against various other Excel reading gems comparing parsing speed, memory usage, and allocations.
+Jamie Schembri did a shootout of Xsv against various other Excel reading gems comparing parsing speed, memory usage, and
+allocations.
 Check our his blog post: [Faster Excel parsing in Ruby](https://blog.schembri.me/post/faster-excel-parsing-in-ruby/).
 
-Pre-1.0, Xsv used a native extension for XML parsing, which was faster than the native Ruby one (on MRI). But even with the native Ruby version generally Xsv still outperforms the competition.
+Pre-1.0, Xsv used a native extension for XML parsing, which was faster than the native Ruby one (on MRI). But even
+the current native Ruby parser generally outperforms the competition. For maximum performance, it is recommended to
+enable YJIT.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,12 @@ Xsv has two modes of operation. By default, it returns an array for
 each row in the sheet:
 
 ```ruby
-x = Xsv.open("sheet.xlsx") # => #<Xsv::Workbook sheets=1>
+workbook = Xsv.open("sheet.xlsx") # => #<Xsv::Workbook sheets=1>
 
-sheet = x.sheets[0]
+# Access worksheet by index, 0 is the first sheet
+sheet = workbook[0]
+# or, access worksheet by name
+sheet = workbook["Sheet1"]
 
 # Iterate over rows
 sheet.each do |row|
@@ -65,15 +68,16 @@ option on open:
 ```ruby
 # Parse headers for all sheets on open
 
-x = Xsv.open("sheet.xlsx", parse_headers: true)
+workbook = Xsv.open("sheet.xlsx", parse_headers: true)
 
-x.sheets[0][1]   # => {"header1" => "value1", "header2" => "value2"}
+# Get the first row from the first sheet
+workbook.first.first   # => {"header1" => "value1", "header2" => "value2"}
 
 # Manually parse headers for a single sheet
 
-x = Xsv.open("sheet.xlsx")
+workbook = Xsv.open("sheet.xlsx")
 
-sheet = x.sheets[0]
+sheet = workbook[0]
 
 sheet[0]  # => ["header1", "header2"]
 
@@ -86,7 +90,13 @@ Xsv will raise `Xsv::DuplicateHeaders` if it detects duplicate values in the hea
 `#parse_headers!` or when opening a workbook with `parse_headers: true` to ensure hash keys are unique.
 
 `Xsv::Sheet` implements `Enumerable` so along with `#each`
-you can call methods like `#first`, `#filter`/`#select`, and `#map` on it.
+you can call methods like `#first`, `#filter`/`#select`, and `#map` on it. Likewise these methods can
+be used on `Xsv::Workbook` to iterate over sheets, for example:
+
+```ruby
+# Get the name of all the sheets in a workbook
+sheet_names = @workbook.map(&:name)
+```
 
 ### Opening a string or buffer instead of filename
 
@@ -111,24 +121,6 @@ end
 
 Prior to Xsv 1.1.0, `Xsv::Workbook.open` was used instead of `Xsv.open`. The parameters are identical and
 the former is maintained for backwards compatibility.
-
-### Accessing sheets by name
-
-The sheets can be accessed by index or by name:
-
-```ruby
-x = Xsv.open("sheet.xlsx")
-
-sheet = x.sheets[0] # gets sheet by index
-
-sheet = x.sheets_by_name('Name').first # gets sheet by name
-```
-
-To get all the sheets names:
-
-```ruby
-sheet_names = x.sheets.map(&:name)
-```
 
 ### Assumptions
 

--- a/lib/xsv/sheet.rb
+++ b/lib/xsv/sheet.rb
@@ -30,13 +30,11 @@ module Xsv
     #
     # @param workbook [Workbook] The Workbook with shared data such as shared strings and styles
     # @param io [IO] A handle to an open worksheet XML file
-    # @param size [Number] size of the XML file
-    def initialize(workbook, io, size, ids)
+    def initialize(workbook, io, ids)
       @workbook = workbook
       @id = ids[:sheetId].to_i
       @io = io
       @name = ids[:name]
-      @size = size
       @headers = []
       @mode = :array
       @row_skip = 0
@@ -58,11 +56,7 @@ module Xsv
     # Iterate over rows, returning either hashes or arrays based on the current mode.
     def each_row(&block)
       @io.rewind
-
-      handler = SheetRowsHandler.new(@mode, empty_row, @workbook, @row_skip, @last_row, &block)
-
-      handler.parse(@io)
-
+      SheetRowsHandler.new(@mode, empty_row, @workbook, @row_skip, @last_row, &block).parse(@io)
       true
     end
 

--- a/lib/xsv/workbook.rb
+++ b/lib/xsv/workbook.rb
@@ -98,7 +98,7 @@ module Xsv
             r[:Type].end_with?("worksheet")
         end
         sheet_ids = @sheet_ids.detect { |i| i[:id] == rel[:Id] }
-        Xsv::Sheet.new(self, entry.get_input_stream, entry.size, sheet_ids).tap do |sheet|
+        Xsv::Sheet.new(self, entry.get_input_stream, sheet_ids).tap do |sheet|
           sheet.parse_headers! if mode == :hash
         end
       end

--- a/lib/xsv/workbook.rb
+++ b/lib/xsv/workbook.rb
@@ -6,6 +6,8 @@ module Xsv
   # An OOXML Spreadsheet document is called a Workbook. A Workbook consists of
   # multiple Sheets that are available in the array that's accessible through {#sheets}
   class Workbook
+    include Enumerable
+
     # Access the Sheet objects contained in the workbook
     # @return [Array<Sheet>]
     attr_reader :sheets
@@ -67,6 +69,24 @@ module Xsv
     # Get number format for given style index
     def get_num_fmt(style)
       @num_fmts[@xfs[style][:numFmtId]]
+    end
+
+    def each(&block)
+      sheets.each(&block)
+    end
+
+    # Get a sheet by index or name
+    # @param [String, Integer] index_or_name The name of the sheet or index in the workbook
+    # @return [<Xsv::Sheet>, nil] returns the sheet instance or nil if it was not found
+    def [](index_or_name)
+      case index_or_name
+      when Integer
+        sheets[index_or_name]
+      when String
+        sheets_by_name(index_or_name).first
+      else
+        raise ArgumentError, "Sheets can be accessed by Integer of String only"
+      end
     end
 
     private

--- a/test/workbook_test.rb
+++ b/test/workbook_test.rb
@@ -112,4 +112,52 @@ class WorkbookTest < Minitest::Test
     assert_equal "2022-03-04 12:00:00 AM", @sheet[0]["Date"]
     assert_equal "ABC123", @sheet[0]["Value"]
   end
+
+  def test_index_open_by_index
+    @workbook = Xsv.open(File.read("test/files/office365-xl7.xlsx"))
+
+    sheet = @workbook[1]
+    assert_equal "Blad2", sheet.name
+  end
+
+  def test_index_open_by_out_of_range_index
+    @workbook = Xsv.open(File.read("test/files/office365-xl7.xlsx"))
+
+    sheet = @workbook[99]
+    assert_nil sheet
+  end
+
+  def test_index_open_by_name
+    @workbook = Xsv.open(File.read("test/files/office365-xl7.xlsx"))
+
+    sheet = @workbook["Blad2"]
+    assert_equal "Blad2", sheet.name
+  end
+
+  def test_index_open_by_nonexistent_name
+    @workbook = Xsv.open(File.read("test/files/office365-xl7.xlsx"))
+
+    sheet = @workbook["Blad99"]
+    assert_nil sheet
+  end
+
+  def test_index_open_by_invalid_type
+    @workbook = Xsv.open(File.read("test/files/office365-xl7.xlsx"))
+
+    assert_raises ArgumentError do
+      @workbook[true]
+    end
+  end
+
+  def test_first
+    @workbook = Xsv.open(File.read("test/files/office365-xl7.xlsx"))
+
+    assert_equal "Blad1", @workbook.first.name
+  end
+
+  def test_enumerable
+    @workbook = Xsv.open(File.read("test/files/office365-xl7.xlsx"))
+
+    assert_equal %w(Blad1 Blad2 Blad3), @workbook.map(&:name)
+  end
 end


### PR DESCRIPTION
This replaces the `sheets` and `get_sheets_name` with more convenient `[name_or_index]` and  `Enumerable` access.