### PR TITLE
Make Sheet#each_row return Enumerator when no block

### DIFF
--- a/lib/xsv/sheet.rb
+++ b/lib/xsv/sheet.rb
@@ -55,6 +55,8 @@ module Xsv
 
     # Iterate over rows, returning either hashes or arrays based on the current mode.
     def each_row(&block)
+      return to_enum(__method__) unless block
+
       @io.rewind
       SheetRowsHandler.new(@mode, @headers, empty_row, @workbook, @row_skip, @last_row, &block).parse(@io)
       true

--- a/test/sheet_test.rb
+++ b/test/sheet_test.rb
@@ -13,6 +13,17 @@ class SheetTest < Minitest::Test
     assert_equal 2, filtered_rows.length
   end
 
+  def test_each_enumerator
+    @workbook = Xsv.open("test/files/excel2016.xlsx")
+    sheet = @workbook.sheets[0]
+
+    last_row_index = nil
+    sheet.each.with_index do |row, index|
+      last_row_index = index
+    end
+    assert_equal 3, last_row_index
+  end
+
   def test_empty
     @workbook = Xsv.open("test/files/empty.xlsx")
     sheet = @workbook.sheets[0]


### PR DESCRIPTION
This allows for chaining Enumerators, e.g.

    sheet.each.with_index do |row, index|
        # ...
    end

and matches behaviour of `Array#each`/`Hash#each`

    enum = [1, 2, 3].each # => #<Enumerator: ...>
    enum.peek # => 1