### PR TITLE
SheetBoundsHandler returns 0 rows for sheets with only inlineStr cells

### DIFF
--- a/lib/xsv/sheet_bounds_handler.rb
+++ b/lib/xsv/sheet_bounds_handler.rb
@@ -40,7 +40,7 @@ module Xsv
       when "c"
         @state = name
         @cell = attrs[:r]
-      when "v"
+      when "v", "is"
         col = column_index(@cell)
         @max_column = col if col > @max_column
         @max_row = @row if @row > @max_row

--- a/test/files/inlineStr-no-dimension.xml
+++ b/test/files/inlineStr-no-dimension.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheetData>
+    <row r="1">
+      <c r="A1" t="inlineStr"><is><t>Header1</t></is></c>
+      <c r="B1" t="inlineStr"><is><t>Header2</t></is></c>
+    </row>
+    <row r="2">
+      <c r="A2" t="inlineStr"><is><t>Value1</t></is></c>
+      <c r="B2" t="inlineStr"><is><t>Value2</t></is></c>
+    </row>
+    <row r="3">
+      <c r="A3" t="inlineStr"><is><t>Value3</t></is></c>
+      <c r="B3" t="inlineStr"><is><t>Value4</t></is></c>
+    </row>
+  </sheetData>
+</worksheet>

--- a/test/sheet_bounds_handler_test.rb
+++ b/test/sheet_bounds_handler_test.rb
@@ -12,4 +12,12 @@ class SheetBoundsHandlerTest < Minitest::Test
     assert_equal 4, rows
     assert_equal 8, cols
   end
+
+  def test_sheet_bounds_with_inline_strings_without_dimension
+    sheet = File.open("test/files/inlineStr-no-dimension.xml")
+    rows, cols = Xsv::SheetBoundsHandler.get_bounds(sheet, @workbook)
+
+    assert_equal 3, rows
+    assert_equal 2, cols
+  end
 end


### PR DESCRIPTION
When a sheet has no `<dimension>` range (or a single-cell ref like ref="A1") and cells use t="inlineStr", get_bounds returns (0, 0) because it only looks for `<v>` elements.

SheetRowsHandler already handles `<is>`, but SheetBoundsHandler was not.

Fix: added `"is"` to the `"v"` check
Test: added a fixture without a range dimension.